### PR TITLE
[feat] 회원가입 유효성 검사 및 중복 검사 - #4

### DIFF
--- a/board/src/main/java/server/board/domain/home/service/HomeService.java
+++ b/board/src/main/java/server/board/domain/home/service/HomeService.java
@@ -12,8 +12,11 @@ import server.board.domain.home.dto.LoginRequestDto;
 import server.board.domain.user.dto.UserCreateRequestDto;
 import server.board.domain.user.entity.User;
 import server.board.domain.user.repository.UserRepository;
+import server.board.global.exception.error.RestApiException;
 import server.board.global.jwt.JwtToken;
 import server.board.global.jwt.JwtTokenProvider;
+
+import static server.board.global.exception.error.CustomErrorCode.DUPLICATE_USER;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +35,12 @@ public class HomeService {
         return jwtTokenProvider.generateToken(authentication);
     }
 
+    @Transactional
     public void signUp(@Valid UserCreateRequestDto userCreateRequestDto) {
+        // 중복되는 이메일(유저)가 있다면 중복 에러 발생
+        if (userRepository.existsByEmail(userCreateRequestDto.getEmail())) {
+            throw new RestApiException(DUPLICATE_USER);
+        }
         userRepository.save(User.create(
                 userCreateRequestDto,
                 bCryptPasswordEncoder.encode(userCreateRequestDto.getPassword())

--- a/board/src/main/java/server/board/domain/user/dto/UserCreateRequestDto.java
+++ b/board/src/main/java/server/board/domain/user/dto/UserCreateRequestDto.java
@@ -1,5 +1,9 @@
 package server.board.domain.user.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +14,19 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserCreateRequestDto {
 
+    @Email
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Size(max = 50, message = "입력된 이메일의 길이가 너무 깁니다.")
+    @Pattern(regexp = "^[\\w!#$%&'*+/=?`{|}~^.-]+@[\\w.-]+\\.[a-zA-Z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
+    @NotBlank(message = "패스워드는 필수입니다.")
+    @Size(max = 100, message = "입력된 비밀번호의 길이가 너무 깁니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]{8,16}$", message = "비밀번호는 8~16자의 영문 대소문자, 숫자, 특수문자로 이루어져야 합니다.")
     private String password;
 
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 20, message = "입력된 이름의 길이가 너무 깁니다.")
     private String name;
 
     private String part;

--- a/board/src/main/java/server/board/domain/user/repository/UserRepository.java
+++ b/board/src/main/java/server/board/domain/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByEmail(String email);
 
     List<User> findByPart(String part);
+
+    boolean existsByEmail(String email);
 }

--- a/board/src/main/java/server/board/global/exception/error/CustomErrorCode.java
+++ b/board/src/main/java/server/board/global/exception/error/CustomErrorCode.java
@@ -19,6 +19,9 @@ public enum CustomErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404,"존재하지 않는 회원"),
     TASK_NOT_FOUND(HttpStatus.NOT_FOUND, 404,"존재하지 않는 과제"),
 
+    // 409 CONFLICT
+    DUPLICATE_USER(HttpStatus.CONFLICT, 409, "이미 가입된 이메일입니다."),
+
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류 발생");
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #4 

## 🛠 구현 사항
- 이메일(회원) 중복 검사 및 예외처리
- UserCreateRequestDto의 유효성 검사 어노테이션 추가

## 🤔 추가 고려 사항
- 에러가 발생하는 필드 별로 예외 처리 구현  
-> 현재는 INVALID_REQUEST 로 한 번에 묶어서 처리