### PR TITLE
[fix] 로그인 시 예외처리

### DIFF
--- a/board/src/main/java/server/board/domain/home/service/HomeService.java
+++ b/board/src/main/java/server/board/domain/home/service/HomeService.java
@@ -1,10 +1,11 @@
 package server.board.domain.home.service;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,11 +13,10 @@ import server.board.domain.home.dto.LoginRequestDto;
 import server.board.domain.user.dto.UserCreateRequestDto;
 import server.board.domain.user.entity.User;
 import server.board.domain.user.repository.UserRepository;
+import server.board.global.exception.error.CustomErrorCode;
 import server.board.global.exception.error.RestApiException;
 import server.board.global.jwt.JwtToken;
 import server.board.global.jwt.JwtTokenProvider;
-
-import static server.board.global.exception.error.CustomErrorCode.DUPLICATE_USER;
 
 @Service
 @RequiredArgsConstructor
@@ -28,18 +28,24 @@ public class HomeService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Transactional(readOnly = true)
-    public JwtToken signIn(@Valid LoginRequestDto loginRequestDto) {
-        UsernamePasswordAuthenticationToken authenticationToken
-                = new UsernamePasswordAuthenticationToken(loginRequestDto.getEmail(), loginRequestDto.getPassword());
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        return jwtTokenProvider.generateToken(authentication);
+    public JwtToken signIn(LoginRequestDto loginRequestDto) {
+        userRepository.findByEmail(loginRequestDto.getEmail())
+                .orElseThrow(() -> new RestApiException(CustomErrorCode.USER_NOT_FOUND));
+        try {
+            UsernamePasswordAuthenticationToken authenticationToken
+                    = new UsernamePasswordAuthenticationToken(loginRequestDto.getEmail(), loginRequestDto.getPassword());
+            Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+            return jwtTokenProvider.generateToken(authentication);
+        } catch (BadCredentialsException e) {
+            throw new RestApiException(CustomErrorCode.INVALID_PASSWORD_VALUE);
+        }
     }
 
     @Transactional
-    public void signUp(@Valid UserCreateRequestDto userCreateRequestDto) {
+    public void signUp(UserCreateRequestDto userCreateRequestDto) {
         // 중복되는 이메일(유저)가 있다면 중복 에러 발생
         if (userRepository.existsByEmail(userCreateRequestDto.getEmail())) {
-            throw new RestApiException(DUPLICATE_USER);
+            throw new RestApiException(CustomErrorCode.DUPLICATE_USER);
         }
         userRepository.save(User.create(
                 userCreateRequestDto,

--- a/board/src/main/java/server/board/global/exception/error/CustomErrorCode.java
+++ b/board/src/main/java/server/board/global/exception/error/CustomErrorCode.java
@@ -11,6 +11,7 @@ public enum CustomErrorCode implements ErrorCode {
     //400 Bad Request
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "인자값이 유효하지 않음"),
     INVALID_PART_VALUE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 파트입니다."),
+    INVALID_PASSWORD_VALUE(HttpStatus.BAD_REQUEST, 400, "일치하지 않은 패스워드입니다."),
 
     // 403 Forbidden
     ASSIGNMENT_MODIFY_FORBIDDEN(HttpStatus.FORBIDDEN, 403, "로그인한 유저의 해당 과제 수정 권한이 없음"),


### PR DESCRIPTION
📋 이슈 번호

🛠 구현 사항
- 로그인 시 발생할 수 있는 예외상황
> 1. 존재하지 않는 이메일: UsernameNotFoundException
**해결방법**: signIn 메서드 첫 줄에서 이메일과 일치하는 유저가 있는지 확인 후 없다면 RestApiException(CustomErrorCode.USER_NOT_FOUND)
> 2. 일치하지 않는 패스워드: BadCredentialsException
**해결방법**: 토큰 발급 과정을 try 문으로 감싸고 패스워드가 일치하지 않는다면RestApiException(CustomErrorCode.INVALID_PASSWORD_VALUE)

🤔 추가 고려 사항