### PR TITLE
[fix] 없는 데이터 Get 요청 시 빈 리스트 반환

### DIFF
--- a/board/src/main/java/server/board/domain/user/dto/UserCreateRequestDto.java
+++ b/board/src/main/java/server/board/domain/user/dto/UserCreateRequestDto.java
@@ -23,14 +23,14 @@ public class UserCreateRequestDto {
 
     @Schema(description = "패스워드", example = "Appcenter1234@")
     @NotBlank(message = "패스워드는 필수입니다.")
-    @Pattern(regexp = "^[a-zA-Z0-9!@#$%^&*]{8,16}$", message = "비밀번호는 8~16자의 영문 대소문자, 숫자, 특수문자로 이루어져야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,16}$", message = "비밀번호는 8~16자의 영문 대소문자, 숫자, 특수문자로 이루어져야 합니다.")
     private String password;
 
     @Schema(description = "이름", example = "홍길동")
     @NotBlank(message = "이름은 필수입니다.")
     private String name;
 
-    @Schema(description = "파트", example = "베이직")
+    @Schema(description = "파트", example = "basic")
     private String part;
 
     @Schema(description = "기수", example = "17.5")

--- a/board/src/main/java/server/board/domain/user/service/UserService.java
+++ b/board/src/main/java/server/board/domain/user/service/UserService.java
@@ -22,11 +22,9 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public List<UserResponseDto> findAll() {
-        // repository 에서 전체 유저 조회 (없다면 에러 발생)
+        // repository 에서 전체 유저 조회
         List<User> userList = userRepository.findAll();
-        if (userList.isEmpty()) {
-            throw new RestApiException(USER_NOT_FOUND);
-        }
+
         // 응답 전용 객체로 변환 및 반환
         List<UserResponseDto> userResponseDtoList = new ArrayList<>();
         for (User user : userList) {
@@ -37,11 +35,9 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public List<UserResponseDto> findByPart(String part) {
-        // repository 에서 파트 유저 조회 (없다면 에러 발생)
+        // repository 에서 파트 유저 조회
         List<User> userList = userRepository.findByPart(Part.from(part));
-        if (userList.isEmpty()) {
-            throw new RestApiException(USER_NOT_FOUND);
-        }
+
         // 응답 전용 객체로 변환 및 반환
         List<UserResponseDto> userResponseDtoList = new ArrayList<>();
         for (User user : userList) {


### PR DESCRIPTION
📋 이슈 번호

🛠 구현 사항
- 전체 유저 조회(/api/users), 파트 유저 조회(/api/users/{parts})
> 기존: 요청한 데이터가 비어있다면 에러를 발생
> 수정: 빈 리스트를 반환

🤔 추가 고려 사항